### PR TITLE
Enhance #find_last to handle models backed by UUIDs

### DIFF
--- a/lib/cucumber_factory/switcher.rb
+++ b/lib/cucumber_factory/switcher.rb
@@ -4,10 +4,12 @@ module CucumberFactory
 
     def find_last(klass)
       # Don't use class.last, in sqlite that is not always the last inserted element
+      # If created_at is available prefer it over id as column for ordering so that we can handle UUIDs
+      order_column = klass.column_names.include?('created_at') ? 'created_at, id' : 'id'
       if Rails::VERSION::MAJOR < 4
-        klass.find(:last, :order => "id")
+        klass.find(:last, :order => order_column)
       else
-        klass.order(:id).last
+        klass.order(order_column).last
       end
     end
 

--- a/spec/shared/app_root/db/migrate/002_create_users.rb
+++ b/spec/shared/app_root/db/migrate/002_create_users.rb
@@ -9,6 +9,7 @@ class CreateUsers < ActiveRecord::Migration
       t.boolean :subscribed
       t.boolean :scared
       t.boolean :scared_by_spiders
+      t.datetime :created_at
     end
   end
 

--- a/spec/shared/cucumber_factory/steps_spec.rb
+++ b/spec/shared/cucumber_factory/steps_spec.rb
@@ -154,6 +154,19 @@ describe 'steps provided by cucumber_factory' do
 
   it "should allow to set a belongs_to association to a previously created record by saying 'above'" do
     invoke_cucumber_step('there is a user with the name "Jane"')
+    invoke_cucumber_step('there is a user with the name "John"')
+    invoke_cucumber_step('there is a movie with the title "Limitless"')
+    invoke_cucumber_step('there is a movie with the title "Before Sunrise"')
+    invoke_cucumber_step('there is a movie with the title "Before Sunset" and the reviewer above and the prequel above')
+    before_sunset = Movie.find_by_title!("Before Sunset")
+    before_sunset.prequel.title.should == "Before Sunrise"
+    before_sunset.reviewer.name.should == "John"
+  end
+
+  it "should give created_at precedence over id when saying 'above' so that records with UUIDs are handled correctly" do
+    invoke_cucumber_step('there is a user with the name "Jane"')
+    invoke_cucumber_step('there is a user with the name "John"')
+    User.find_by_name("John").update_attributes!(:created_at => 1.day.ago)
     invoke_cucumber_step('there is a movie with the title "Limitless"')
     invoke_cucumber_step('there is a movie with the title "Before Sunrise"')
     invoke_cucumber_step('there is a movie with the title "Before Sunset" and the reviewer above and the prequel above')


### PR DESCRIPTION
The #find_last method in CucumberFactory::Switcher ordered by *id to find the last record. That did not work with models backed with an UUID, or more generally, with models where you couldn't be sure that the *id column was in a certain order. Now #find_last orders by *created_at if available, otherwise it falls back to *id.