### PR TITLE
Add single quote support to cucumber factory. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 -
 
+## 2.0.0 - 2020-02-10
+
+### Breaking changes
+
+- CucumberFactory now raises an `ArgumentError` if some parts of a matched step were not used. For example, while this step was accepted in recent versions, it will now complain with the message `Unable to parse attributes " and the ".`:
+  ```
+  Given there is a user with the attribute 'foo' and the
+  ```
+
+
+### Compatible changes
+
+- Single quoted attribute values and model names are now supported. Example:
+
+  ```
+  Given 'jack' is a user with the first name 'Jack'
+  ```
+
 ## 1.15.1 - 2019-05-30
 
 ### Compatible changes

--- a/Gemfile.cucumber-2.4.lock
+++ b/Gemfile.cucumber-2.4.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cucumber_factory (1.15.1)
+    cucumber_factory (2.0.0)
       activerecord
       activesupport
       cucumber

--- a/Gemfile.cucumber-2.4.lock
+++ b/Gemfile.cucumber-2.4.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cucumber_factory (1.15.0)
+    cucumber_factory (1.15.1)
       activerecord
       activesupport
       cucumber
@@ -81,4 +81,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/Gemfile.cucumber-3.0.lock
+++ b/Gemfile.cucumber-3.0.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cucumber_factory (1.15.1)
+    cucumber_factory (2.0.0)
       activerecord
       activesupport
       cucumber

--- a/Gemfile.cucumber-3.0.lock
+++ b/Gemfile.cucumber-3.0.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cucumber_factory (1.15.0)
+    cucumber_factory (1.15.1)
       activerecord
       activesupport
       cucumber
@@ -86,4 +86,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/Gemfile.cucumber-3.1.lock
+++ b/Gemfile.cucumber-3.1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cucumber_factory (1.15.1)
+    cucumber_factory (2.0.0)
       activerecord
       activesupport
       cucumber

--- a/Gemfile.cucumber-3.1.lock
+++ b/Gemfile.cucumber-3.1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cucumber_factory (1.15.0)
+    cucumber_factory (1.15.1)
       activerecord
       activesupport
       cucumber
@@ -86,4 +86,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -190,8 +190,13 @@ Development
 
 There are tests in `spec`. We only accept PRs with tests. To run tests:
 
-- Install Ruby 2.5.3
-- Create a local MySQL database `cucumber_factory_test`
+- Install the Ruby version stated in `.ruby-version`
+- Create a local MySQL/MariaDB database named `cucumber_factory_test`
+```
+$ mysql -u root -p
+> create database cucumber_factory_test;
+```
+
 - Copy `spec/support/database.sample.yml` to `spec/support/database.yml` and enter your local credentials for the test databases
 - Install development dependencies using `bundle install`
 - Run tests with the default symlinked Gemfile using `bundle exec rspec` or explicit with `BUNDLE_GEMFILE=Gemfile.cucumber-x.x bundle exec rspec spec`

--- a/lib/cucumber_factory/factory.rb
+++ b/lib/cucumber_factory/factory.rb
@@ -104,10 +104,15 @@ module CucumberFactory
         model_class = build_strategy.model_class
         attributes = {}
         if raw_attributes.try(:strip).present?
-          raw_attributes.scan(/(?:the |and |with |but |,| )+(.*?) (#{VALUE_SCALAR}|#{VALUE_ARRAY}|#{VALUE_LAST_RECORD})/).each do |fragment|
+          raw_attribute_fragment_regex = /(?:the |and |with |but |,| )+(.*?) (#{VALUE_SCALAR}|#{VALUE_ARRAY}|#{VALUE_LAST_RECORD})/
+          raw_attributes.scan(raw_attribute_fragment_regex).each do |fragment|
             attribute = attribute_name_from_prose(fragment[0])
             value = fragment[1]
             attributes[attribute] = attribute_value(world, model_class, attribute, value)
+          end
+          unused_raw_attributes = raw_attributes.gsub(raw_attribute_fragment_regex, '')
+          if unused_raw_attributes.present?
+            raise ArgumentError, "Unable to parse attributes #{unused_raw_attributes.inspect}."
           end
         end
         if raw_boolean_attributes.try(:strip).present?

--- a/lib/cucumber_factory/factory.rb
+++ b/lib/cucumber_factory/factory.rb
@@ -6,13 +6,13 @@ module CucumberFactory
     TEXT_ATTRIBUTES_PATTERN = ' (?:with|and) these attributes:'
 
     RECORD_PATTERN = 'there is an? (.+?)( \(.+?\))?'
-    NAMED_RECORD_PATTERN = '"([^\"]*)" is an? (.+?)( \(.+?\))?'
+    NAMED_RECORD_PATTERN = '(?:"([^\"]*)"|\'([^\']*)\') is an? (.+?)( \(.+?\))?'
 
     NAMED_RECORDS_VARIABLE = :'@named_cucumber_factory_records'
 
     VALUE_INTEGER = /\d+/
     VALUE_DECIMAL = /[\d\.]+/
-    VALUE_STRING = /"[^"]*"/
+    VALUE_STRING = /"[^"]*"|'[^']*'/
     VALUE_ARRAY = /\[[^\]]*\]/
     VALUE_LAST_RECORD = /\babove\b/
 
@@ -30,7 +30,7 @@ module CucumberFactory
     NAMED_CREATION_STEP_DESCRIPTOR = {
       :kind => :Given,
       :pattern => /^#{NAMED_RECORD_PATTERN}#{ATTRIBUTES_PATTERN}?$/,
-      :block => lambda { |a1, a2, a3, a4, a5| CucumberFactory::Factory.send(:parse_named_creation, self, a1, a2, a3, a4, a5) }
+      :block => lambda { |a1, a2, a3, a4, a5, a6| CucumberFactory::Factory.send(:parse_named_creation, self, a1, a2, a3, a4, a5, a6) }
     }
 
     CREATION_STEP_DESCRIPTOR = {
@@ -42,7 +42,7 @@ module CucumberFactory
     NAMED_CREATION_STEP_DESCRIPTOR_WITH_TEXT_ATTRIBUTES = {
       :kind => :Given,
       :pattern => /^"#{NAMED_RECORD_PATTERN}#{ATTRIBUTES_PATTERN}#{TEXT_ATTRIBUTES_PATTERN}?$/,
-      :block => lambda { |a1, a2, a3, a4, a5, a6| CucumberFactory::Factory.send(:parse_named_creation, self, a1, a2, a3, a4, a5, a6) },
+      :block => lambda { |a1, a2, a3, a4, a5, a6, a7| CucumberFactory::Factory.send(:parse_named_creation, self, a1, a2, a3, a4, a5, a6, a7) },
       :priority => true
     }
 
@@ -93,8 +93,9 @@ module CucumberFactory
         named_records(world)[name] = record
       end
 
-      def parse_named_creation(world, name, raw_model, raw_variant, raw_attributes, raw_boolean_attributes, raw_multiline_attributes = nil)
+      def parse_named_creation(world, double_quote_name, single_quote_name, raw_model, raw_variant, raw_attributes, raw_boolean_attributes, raw_multiline_attributes = nil)
         record = parse_creation(world, raw_model, raw_variant, raw_attributes, raw_boolean_attributes, raw_multiline_attributes)
+        name = [double_quote_name, single_quote_name].compact.first
         set_named_record(world, name, record)
       end
 

--- a/lib/cucumber_factory/version.rb
+++ b/lib/cucumber_factory/version.rb
@@ -1,3 +1,3 @@
 module CucumberFactory
-  VERSION = '1.15.1'
+  VERSION = '2.0.0'
 end

--- a/spec/cucumber_factory/steps_spec.rb
+++ b/spec/cucumber_factory/steps_spec.rb
@@ -434,4 +434,28 @@ tags: ["foo", "bar"]
     obj.attributes[:tags].should == ['foo', 'bar']
   end
 
+  it "should allow single quote for attribute values" do
+    MachinistModel.should_receive(:make).with({ :attribute => "foo"})
+    invoke_cucumber_step("there is a machinist model with the attribute 'foo'")
+  end
+
+  it "should allow mixed single and double quotes for different attribute values" do
+    MachinistModel.should_receive(:make).with({ :attribute => "foo", :other_attribute => "bar" })
+    invoke_cucumber_step("there is a machinist model with the attribute 'foo' and the other attribute \"bar\"")
+  end
+
+  it "should allow mixed single quotes for model names" do
+    invoke_cucumber_step("'Some Prequel' is a movie with the title \"Before Sunrise\"")
+    invoke_cucumber_step('there is a movie with the title "Limitless"')
+    invoke_cucumber_step('there is a movie with the title \'Before Sunset\' and the prequel "Some Prequel"')
+    movie = Movie.find_by_title!('Before Sunset')
+    prequel = Movie.find_by_title!('Before Sunrise')
+    movie.prequel.should == prequel
+  end
+
+  it 'should not raise an error for a blank instance name' do
+    MachinistModel.should_receive(:make).with({ :attribute => 'foo' })
+    invoke_cucumber_step("'' is a machinist model with the attribute 'foo'")
+  end
+
 end

--- a/spec/cucumber_factory/steps_spec.rb
+++ b/spec/cucumber_factory/steps_spec.rb
@@ -458,4 +458,11 @@ tags: ["foo", "bar"]
     invoke_cucumber_step("'' is a machinist model with the attribute 'foo'")
   end
 
+  it 'should warn if there are unused fragments' do
+    MachinistModel.should_not_receive(:make)
+    lambda { invoke_cucumber_step("there is a machinist model with the attribute NOQUOTES") }.should raise_error(ArgumentError, 'Unable to parse attributes " with the attribute NOQUOTES".')
+    lambda { invoke_cucumber_step("there is a machinist model with the attribute 'foo' and the ") }.should raise_error(ArgumentError, 'Unable to parse attributes " and the ".')
+    lambda { invoke_cucumber_step("there is a machinist model with the attribute 'foo'. the other_attribute 'bar' and the third attribute 'baz'") }.should raise_error(ArgumentError, 'Unable to parse attributes ".".')
+  end
+
 end


### PR DESCRIPTION
This PR includes two changes:
1) Single quote attribute and model names are now supported
2) CucumberFactory now raises if it did not use parts of the matched steps

A few notes:
* Tests are green with Ruby 2.1.10 and 2.5.3. I did not manage to get 1.8.7 running, it it's already broken in the `master` branch.
* Because of (2) we will see a few red features in existing projects - those were ignored silently until now. I think this is a good thing.
* Tested two larger real-world applications.
* This closes https://github.com/makandra/cucumber_factory/issues/29