### PR TITLE
[#28] Fix named records for multiline attribute assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 -
 
+## 2.0.1 - 2020-02-27
+
+### Compatible changes
+
+- Fix a bug that prevented created records to be named when using multiline attribute assignments
+  ```
+  Given "Bob" is a user with these attributes:
+    | email | foo@bar.com     |
+  ```
+
 ## 2.0.0 - 2020-02-10
 
 ### Breaking changes

--- a/Gemfile.cucumber-2.4.lock
+++ b/Gemfile.cucumber-2.4.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cucumber_factory (2.0.0)
+    cucumber_factory (2.0.1)
       activerecord
       activesupport
       cucumber

--- a/Gemfile.cucumber-3.0.lock
+++ b/Gemfile.cucumber-3.0.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cucumber_factory (2.0.0)
+    cucumber_factory (2.0.1)
       activerecord
       activesupport
       cucumber

--- a/Gemfile.cucumber-3.1.lock
+++ b/Gemfile.cucumber-3.1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cucumber_factory (2.0.0)
+    cucumber_factory (2.0.1)
       activerecord
       activesupport
       cucumber

--- a/lib/cucumber_factory/factory.rb
+++ b/lib/cucumber_factory/factory.rb
@@ -41,7 +41,7 @@ module CucumberFactory
 
     NAMED_CREATION_STEP_DESCRIPTOR_WITH_TEXT_ATTRIBUTES = {
       :kind => :Given,
-      :pattern => /^"#{NAMED_RECORD_PATTERN}#{ATTRIBUTES_PATTERN}#{TEXT_ATTRIBUTES_PATTERN}?$/,
+      :pattern => /^#{NAMED_RECORD_PATTERN}#{ATTRIBUTES_PATTERN}#{TEXT_ATTRIBUTES_PATTERN}?$/,
       :block => lambda { |a1, a2, a3, a4, a5, a6, a7| CucumberFactory::Factory.send(:parse_named_creation, self, a1, a2, a3, a4, a5, a6, a7) },
       :priority => true
     }

--- a/lib/cucumber_factory/version.rb
+++ b/lib/cucumber_factory/version.rb
@@ -1,3 +1,3 @@
 module CucumberFactory
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/spec/cucumber_factory/steps_spec.rb
+++ b/spec/cucumber_factory/steps_spec.rb
@@ -400,6 +400,17 @@ tags: ["foo", "bar"]
     obj.attributes[:tags].should == ['foo', 'bar']
   end
 
+  it 'should allow named records when setting attributes via doc string' do
+    invoke_cucumber_step('"Some Prequel" is a movie with these attributes:', <<-DOC_STRING)
+title: Before Sunrise
+    DOC_STRING
+    invoke_cucumber_step('there is a movie with the title "Limitless"')
+    invoke_cucumber_step('there is a movie with the title "Before Sunset" and the prequel "Some Prequel"')
+    movie = Movie.find_by_title!('Before Sunset')
+    prequel = Movie.find_by_title!('Before Sunrise')
+    movie.prequel.should == prequel
+  end
+
   it "should allow to set attributes via data table" do
     user = User.new
     User.stub(:new => user)
@@ -432,6 +443,17 @@ tags: ["foo", "bar"]
 
     obj = PlainRubyClass.last
     obj.attributes[:tags].should == ['foo', 'bar']
+  end
+
+  it 'should allow named records when setting attributes via data table' do
+    invoke_cucumber_step('"Some Prequel" is a movie with these attributes:', nil, <<-DATA_TABLE)
+| title | Before Sunrise |
+    DATA_TABLE
+    invoke_cucumber_step('there is a movie with the title "Limitless"')
+    invoke_cucumber_step('there is a movie with the title "Before Sunset" and the prequel "Some Prequel"')
+    movie = Movie.find_by_title!('Before Sunset')
+    prequel = Movie.find_by_title!('Before Sunrise')
+    movie.prequel.should == prequel
   end
 
   it "should allow single quote for attribute values" do


### PR DESCRIPTION
I thought this would be a new feature, but was actually already implemented (but not tested & faulty).

See https://github.com/makandra/cucumber_factory/issues/28