### PR TITLE
Fix step collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 -
 
+## 2.3.1 - 2020-10-01
+
+### Compatible changes
+
+- Lowered the priority of all steps in this gem to avoid issues with overlapping steps.
+
 ## 2.3.0 - 2020-09-24
 
 ### Compatible changes

--- a/lib/cucumber_factory/factory.rb
+++ b/lib/cucumber_factory/factory.rb
@@ -4,12 +4,12 @@ module CucumberFactory
 
     ATTRIBUTES_PATTERN = '( with the .+?)?( (?:which|who|that) is .+?)?' # ... with the year 1979 which is science fiction
     TEXT_ATTRIBUTES_PATTERN = ' (?:with|and) these attributes:'
-    UPDATE_ATTR_PATTERN = '(?: (?:has|belongs to)( the .+?))?(?:(?: and| but|,)*( is .+?))?' # ... belongs to the collection "Fantasy" and is trending
+    UPDATE_ATTR_PATTERN = '(?: (?:has|belongs to)( the .+?)|(?: and| but|,)*( is .+?))' # ... belongs to the collection "Fantasy" and is trending
     TEXT_UPDATE_ATTR_PATTERN = '(?: and|,)* has these attributes:'
 
     RECORD_PATTERN = 'there is an? (.+?)( \(.+?\))?' # Given there is a movie (comedy)
     NAMED_RECORD_PATTERN = '(?:"([^\"]*)"|\'([^\']*)\') is an? (.+?)( \(.+?\))?' # Given "LotR" is a movie
-    RECORD_UPDATE_PATTERN = 'the (.+?) (above|".+?"|\'.+?\')' # Given the movie "LotR" ...
+    RECORD_UPDATE_PATTERN = 'the ([^"\',]+?) (above|".+?"|\'.+?\')' # Given the movie "LotR" ...
 
     NAMED_RECORDS_VARIABLE = :'@named_cucumber_factory_records'
 
@@ -45,7 +45,7 @@ module CucumberFactory
 
     UPDATE_STEP_DESCRIPTOR = {
       :kind => :And,
-      :pattern => /^#{RECORD_UPDATE_PATTERN}#{UPDATE_ATTR_PATTERN}$/,
+      :pattern => /^#{RECORD_UPDATE_PATTERN}#{UPDATE_ATTR_PATTERN}+$/,
       :block => lambda { |a1, a2, a3, a4| CucumberFactory::Factory.send(:parse_update, self, a1, a2, a3, a4) }
     }
 
@@ -65,7 +65,7 @@ module CucumberFactory
 
     UPDATE_STEP_DESCRIPTOR_WITH_TEXT_ATTRIBUTES = {
       :kind => :And,
-      :pattern => /^#{RECORD_UPDATE_PATTERN}#{UPDATE_ATTR_PATTERN}#{TEXT_UPDATE_ATTR_PATTERN}$/,
+      :pattern => /^#{RECORD_UPDATE_PATTERN}#{UPDATE_ATTR_PATTERN}*#{TEXT_UPDATE_ATTR_PATTERN}$/,
       :block => lambda { |a1, a2, a3, a4, a5| CucumberFactory::Factory.send(:parse_update, self, a1, a2, a3, a4, a5) },
       :priority => true
     }

--- a/lib/cucumber_factory/factory.rb
+++ b/lib/cucumber_factory/factory.rb
@@ -88,7 +88,8 @@ module CucumberFactory
         main.instance_eval {
           kind = descriptor[:kind]
           object = send(kind, *[descriptor[:pattern]].compact, &descriptor[:block])
-          object.overridable(:priority => descriptor[:priority] ? 1 : 0) if kind != :Before
+          # cucumber_factory steps get a low priority due to their generic syntax
+          object.overridable(:priority => descriptor[:priority] ? -1 : -2) if kind != :Before
           object
         }
       end

--- a/lib/cucumber_factory/version.rb
+++ b/lib/cucumber_factory/version.rb
@@ -1,3 +1,3 @@
 module CucumberFactory
-  VERSION = '2.3.0'
+  VERSION = '2.3.1'
 end


### PR DESCRIPTION
- The priority of all cucumber_factory steps has been reduced to -2 / -1 with text attributes (from 0 / 1 with text attributes)
- The update step will get fewer "false matches" (model names cannot include quotes now, and at least one of `has the`, `belongs to the`, `is` and `has these attributes` has to appear)
Closes #41 